### PR TITLE
Add auth

### DIFF
--- a/catalytic/src/env_property_reader.rs
+++ b/catalytic/src/env_property_reader.rs
@@ -5,6 +5,10 @@ use std::env;
 pub const TEST_DB_KEYSPACE_KEY: &str = "TEST_DB_KEYSPACE_KEY";
 /// Defaults to 127.0.0.1:9042
 pub const SCYLLA_URI: &str = "SCYLLA_URI";
+/// Defaults to cassandra
+pub const SCYLLA_USERNAME: &str = "SCYLLA_USERNAME";
+/// Defaults to cassandra
+pub const SCYLLA_PASSWORD: &str = "SCYLLA_PASSWORD";
 
 pub fn keyspace() -> String {
     env::var(TEST_DB_KEYSPACE_KEY).unwrap_or_else(|_| {
@@ -17,4 +21,12 @@ pub fn keyspace() -> String {
 
 pub fn database_url() -> String {
     env::var(SCYLLA_URI).unwrap_or_else(|_| "127.0.0.1:9042".to_string())
+}
+
+pub fn username() -> String {
+    env::var(SCYLLA_USERNAME).unwrap_or_else(|_| "cassandra".to_string())
+}
+
+pub fn password() -> String {
+    env::var(SCYLLA_PASSWORD).unwrap_or_else(|_| "cassandra".to_string())
 }

--- a/catalytic/src/runtime.rs
+++ b/catalytic/src/runtime.rs
@@ -1,4 +1,4 @@
-use crate::env_property_reader::{database_url, keyspace};
+use crate::env_property_reader::{database_url, keyspace, password, username};
 use once_cell::sync::Lazy;
 use scylla::execution_profile::ExecutionProfileBuilder;
 use scylla::frame::types::Consistency;
@@ -82,6 +82,7 @@ pub async fn create_connection() -> Session {
 
     let session = SessionBuilder::new()
         .known_node(database_url())
+        .user(username(), password())
         .default_execution_profile_handle(
             ExecutionProfileBuilder::default()
                 .consistency(Consistency::One)

--- a/catalytic_table_to_struct/src/entity_writer.rs
+++ b/catalytic_table_to_struct/src/entity_writer.rs
@@ -131,7 +131,6 @@ impl<T: Transformer> EntityWriter<'_, T> {
 
     pub(crate) fn comma_separated_question_marks(&self, amount: usize) -> String {
         (0..amount)
-            .into_iter()
             .map(|_| "?".to_string())
             .collect::<Vec<_>>()
             .join(", ")


### PR DESCRIPTION
Hi, thank you for a such a nice crate.

When I set `--authenticator=PasswordAuthenticator` option on docker and trying to use other profile not the default `cassandra:cassandra`, found it might be better if the auth setting is configurable with env.

It's just a simple modification, would you please take a look at it?
Thanks!